### PR TITLE
Download versions list using github api

### DIFF
--- a/bin/list-all
+++ b/bin/list-all
@@ -1,5 +1,18 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
-echo $(
-  curl --silent https://raw.githubusercontent.com/gingerhot/coq-versions/master/versions.txt
-)
+curl --silent 'https://api.github.com/repos/coq/coq/releases?page=1&per_page=50' | python -c "$(cat <<CODE
+import sys, json
+from operator import itemgetter
+
+def get_versions():
+  l = [
+    r
+    for r in json.load(sys.stdin)
+    if 'tag_name' in r and 'created_at' in r and r['tag_name'].startswith('V')
+  ]
+  l.sort(key=itemgetter('created_at'))
+  return [r['tag_name'][1:] for r in l]
+
+print('\n'.join(get_versions()))
+CODE
+)"


### PR DESCRIPTION
Download versions list using github api with python script.

With this `list-all` will always report a fresh list of versions instead of pulling it from (outdated, at the time of writing) coq-versions repository.

I think we can safely assume that users have python installed on their machines. We can add fallback to the previous method if you think that we shouldn't assume so.

I've tested this script with both python2 and python3.